### PR TITLE
Prevent TypeError

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -134,7 +134,7 @@ var prepare_model_instance_job = function(model, data)
 	return function(model, data) {
 		return function(next) {
 			if (data.id) {
-				model.findOne(data.id).done(function(model, data, next) {
+				model.findOne(data.id).exec(function(model, data, next) {
 					return function(err, obj) {
 						if (obj) {
 							for (var key in data) {
@@ -147,7 +147,7 @@ var prepare_model_instance_job = function(model, data)
 								};
 							}(model, data, next));
 						} else {
-							model.create(data).done(function(next) {
+							model.create(data).exec(function(next) {
 								return function(err, obj) {
 									next(err, obj);
 								};


### PR DESCRIPTION
The .exec will pass and .done will fail in some instances.  done is deprecated version of exec here anyway.
Prevents:
TypeError: Object [object Object] has no method 'done'

See balderdashy/sails#1607 and balderdashy/waterline#381
